### PR TITLE
Use pathnames to determine extension of a file

### DIFF
--- a/file.lisp
+++ b/file.lisp
@@ -12,8 +12,10 @@
 
 (in-package :imago)
 
-
 (defparameter *image-file-readers* (make-hash-table :test #'equal))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (pushnew :imago-fixed-reader *features*))
 
 (defun read-image (filename &key (errorp t))
   "Reads an image from a file. If the file format is not recognized,

--- a/file.lisp
+++ b/file.lisp
@@ -18,10 +18,10 @@
 (defun read-image (filename &key (errorp t))
   "Reads an image from a file. If the file format is not recognized,
 depending on the value of :ERRORP, either throws an error or returns NIL."
-  (let* ((last-dot-position (position #\. filename :from-end t))
-         (extension (and (numberp last-dot-position)
-                         (subseq filename (1+ last-dot-position))))
-         (reader (gethash extension *image-file-readers*)))
+  (declare (type (or pathname string) filename))
+  (let ((reader (gethash
+                 (pathname-type (pathname filename))
+                 *image-file-readers*)))
     (if (null reader)
         (and errorp (error "Unknown file format."))
         (funcall reader filename))))


### PR DESCRIPTION
Many libraries work with pathnames instead of strings when dealing with FS and file I/O, so allow `read-image` to accept pathnames.