### PR TITLE
Add ROTATE

### DIFF
--- a/imago.asd
+++ b/imago.asd
@@ -36,6 +36,7 @@
                (:file "compose" :depends-on ("image" "color"))
                (:file "contrast" :depends-on ("image" "color"))
                (:file "interpolate" :depends-on ("image" "color"))
+               (:file "rotate" :depends-on ("image" "color"))
                (:file "operations" :depends-on ("image" "color"))
                (:file "morphology" :depends-on ("image"))
                (:file "file" :depends-on ("conditions"))

--- a/package.lisp
+++ b/package.lisp
@@ -47,7 +47,7 @@
            #:convert-to-planar #:convert-to-binary ; Aka threshold
 
            #:copy
-           #:flip #:scale #:resize #:crop
+           #:flip #:scale #:resize #:crop #:rotate
            #:*default-interpolation*
 
            #:draw-point #:draw-line

--- a/rotate.lisp
+++ b/rotate.lisp
@@ -1,0 +1,88 @@
+;;; IMAGO library
+;;; Image operations
+;;;
+;;; Copyright (C) 2004-2005  Matthieu Villeneuve (matthieu.villeneuve@free.fr)
+;;;
+;;; The authors grant you the rights to distribute
+;;; and use this software as governed by the terms
+;;; of the Lisp Lesser GNU Public License
+;;; (http://opensource.franz.com/preamble.html),
+;;; known as the LLGPL.
+
+
+(in-package :imago)
+
+;; TODO slots width and height seem superfluous?... We have array dimensions after all.
+
+(defun rotate (image degree &key (interpolation *default-interpolation*)
+                              (background-color (make-default-background-color image)))
+  (let ((degree (mod degree 360))
+        (dimensions (array-dimensions (image-pixels image))))
+    (destructuring-bind (new-height new-width)
+        (rotate-dimensions dimensions degree)
+      (let ((pixels (make-array (list new-height new-width)
+                                :element-type (array-element-type
+                                               (image-pixels image))))
+            (rotator (make-rotator image degree interpolation
+                                   :background-color background-color)))
+        (array-operations/utilities:nested-loop (y x) (array-dimensions pixels)
+          (setf (aref pixels y x) (funcall rotator y x)))
+        (make-instance (class-of image) :pixels pixels
+                                        :width new-width :height new-height)))))
+
+(defun make-rotator (image degree interpolation &key background-color)
+  (labels ((center (dimensions)
+             (map 'list (lambda (x) (/ (1- x) 2)) dimensions)))
+    (let* ((src (image-pixels image))
+           (src-dimensions (array-dimensions src))
+           (dest-dimensions (rotate-dimensions src-dimensions (- degree)))
+           (src-center (center src-dimensions))
+           (dest-center (center dest-dimensions)))
+      (destructuring-bind ((src-height src-width)
+                           (src-center-y src-center-x)
+                           (dest-center-y dest-center-x))
+          (list src-dimensions src-center dest-center)
+        (let* ((radians (* 2 (float pi 1f0) (- degree) 1/360))
+               (cos (cos radians))
+               (sin (sin radians)))
+          (flet ((operate (dest-y dest-x)
+                   (let* ((src-x (/ (+ (* sin (- dest-y dest-center-y))
+                                       (* cos (- dest-x dest-center-x))
+                                       src-center-x)
+                                    (1- src-width)))
+                          (src-y (/ (+ (* cos (- dest-y dest-center-y))
+                                       (- (* sin (- dest-x dest-center-x)))
+                                       src-center-y)
+                                    (1- src-height))))
+                     (declare (type single-float src-x src-y))
+                     ;; FIXME: the background-color border is rough,
+                     ;; interpolate it in the future. This will likely
+                     ;; require passing the background color to
+                     ;; INTERPOLATE-PIXEL though.
+                     (if (and background-color
+                              (or (< src-x 0f0)
+                                  (< 1f0 src-x)
+                                  (< src-y 0f0)
+                                  (< 1f0 src-y)))
+                         background-color
+                         (interpolate-pixel image
+                                            (alex:clamp src-x 0f0 1f0)
+                                            (alex:clamp src-y 0f0 1f0)
+                                            interpolation)))))
+            #'operate))))))
+
+(defgeneric make-default-background-color (image)
+  (:method ((image rgb-image)) (make-color 0 0 0 0))
+  (:method ((image grayscale-image)) (make-gray 0 0)))
+
+(defun rotate-dimensions (dimensions degree)
+  (case degree
+    ((0 180) dimensions)
+    ((90 270) (reverse dimensions))
+    (t (destructuring-bind (height width) dimensions
+         (let* ((radians (* 2 pi degree 1/360))
+                (cos (abs (cos radians)))
+                (sin (abs (sin radians)))
+                (new-width (ceiling (+ (* width cos) (* height sin))))
+                (new-height (ceiling (+ (* width sin) (* height cos)))))
+           (list new-height new-width))))))


### PR DESCRIPTION
This adds a basic operation for rotating images by an arbitrary number of degrees using the already existing interpolation methods.

TODO:

* recognize the `0, 90, 180, 270` cases (mod 360) and simplify behavior for them to simply copy pixels over (possibly `array-operations` can be used for that) instead of doing trigonometry and interpolating
* intepolate the image border - currently there is a hard cutoff between the background color and image pixels which does not look nice (255 alpha → 0 alpha); for no dark borders around the rotated image if we interpolated with an all-0 color, it should be possible to interpolate the colors of the nearest pixel neighbor of the original image except with alpha 0
* update README with the new function and example images
* optimize for speed
* generate example images and write unit tests once the final behavior is satisfying.

Original:

![hatsu2](https://user-images.githubusercontent.com/15045546/147650116-d2ff39a7-86a3-4da1-85d8-dd7ba1e64fed.png)

`(imago:rotate image 45 :interpolation :bicubic)`:

![rotated](https://user-images.githubusercontent.com/15045546/147650150-4334389d-89ac-4692-aa72-b72b9cee80b1.png)